### PR TITLE
Implemented regex matching on the URIs for extra control

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ in your favourite editor (or even notepad) and let's get to it.
 After the line `//  ONLY EDIT BELOW:` you will find the init class and it accepts two array parameters:
   1. Plugins to disable by default
   2. List of URLs where specific plugins should be enabled.
-    * **IMPORTANT** Parts of URL are also matched!
-    * Use regex expressions for extra control [PHP preg-match docs](https://www.php.net/manual/en/function.preg-match.php)
+     1. **IMPORTANT** Parts of URL are also matched!
+     2. Use regex expressions for extra control [PHP preg-match docs](https://www.php.net/manual/en/function.preg-match.php)
 
 ### Example 1
 You want to disable WooCommerce everywhere, except for the shop page and the product pages.
@@ -68,7 +68,7 @@ new SelectivePluginLoader(
 ```
 
 ### Example 3
-Use regex to allow the ajax-search-lite plugin on the home page and the search page, but not on any of the blog posts.
+Use regex to allow the **Ajax Search Lite** plugin on the Wordpress home page and the `/search` page, but not on any of the blog posts.
 
 ```PHP
 //  ONLY EDIT BELOW:
@@ -83,7 +83,7 @@ new SelectivePluginLoader(
 ```
 
 ### Example 4
-Use regex to only allow the monarch social sharing plugin on the blog posts only.
+Use regex to only allow the **Monarch social sharing** plugin on blog posts only (not on the home page).
 
 ```PHP
 //  ONLY EDIT BELOW:
@@ -99,7 +99,7 @@ new SelectivePluginLoader(
 ```
 
 ### Example 5
-Use regex to only allow the context-related-posts plugin on the blog posts but not specific pages with URLs like '/search' and '/faq'
+Use regex to only allow the **Context related posts** plugin on blog posts but not specific pages with URLs like `/search` and `/faq`
 
 ```PHP
 new SelectivePluginLoader(

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ This will automatically include the plugin every time.
 All you need to change is the `plugin.php` file. Open up the `mu-plugins/wpmu-selective-plugin-loader/plugin.php` file
 in your favourite editor (or even notepad) and let's get to it.
 
-After the line `//  ONLY EDIT BELOW:` you will find the init class and it accepts two parameters:
-  * Plugins to disable by default
-  * List of URLs where specific plugins should be enabled. **Parts of URL are also matches!**
+After the line `//  ONLY EDIT BELOW:` you will find the init class and it accepts two array parameters:
+  1. Plugins to disable by default
+  2. List of URLs where specific plugins should be enabled.
+    * **IMPORTANT** Parts of URL are also matched!
+    * Use regex expressions for extra control [PHP preg-match docs](https://www.php.net/manual/en/function.preg-match.php)
 
 ### Example 1
 You want to disable WooCommerce everywhere, except for the shop page and the product pages.
@@ -65,3 +67,48 @@ new SelectivePluginLoader(
 );
 ```
 
+### Example 3
+Use regex to allow the ajax-search-lite plugin on the home page and the search page, but not on any of the blog posts.
+
+```PHP
+//  ONLY EDIT BELOW:
+new SelectivePluginLoader(
+        array(
+                'ajax-search-lite' => 'ajax-search-lite/ajax-search-lite.php'
+        ),
+        array(
+                'ajax-search-lite' => array('/?$', '/search')
+        )
+);
+```
+
+### Example 4
+Use regex to only allow the monarch social sharing plugin on the blog posts only.
+
+```PHP
+//  ONLY EDIT BELOW:
+new SelectivePluginLoader(
+        array(
+                'monarch' => 'monarch/monarch.php'
+        ),
+        array(
+                'monarch' => array('/[^/]+/?$')
+        )
+);
+
+```
+
+### Example 5
+Use regex to only allow the context-related-posts plugin on the blog posts but not specific pages with URLs like '/search' and '/faq'
+
+```PHP
+new SelectivePluginLoader(
+        array(
+                'contextual-related-posts' => 'contextual-related-posts/contextual-related-posts.php'
+        ),
+        array(
+                'contextual-related-posts' => array('(?!/(faq|search))/.+')
+        )
+);
+```
+ 

--- a/plugin.php
+++ b/plugin.php
@@ -11,6 +11,7 @@ require_once "src/SelectivePluginLoader.php";
 new SelectivePluginLoader(
 	/**
 	 * Step 1.
+         *
 	 * This is the list of plugins you want to disable by default, and on step 2. the exceptions are configured.
 	 *
 	 * As you can see, each line represents one plugin "label" => "plugin_dir/plugin_file.php" format.
@@ -18,8 +19,8 @@ new SelectivePluginLoader(
 	 */
 	array(
 		'events' => 'the-events-calendar/the-events-calendar.php',	// The Events Calendar
-		'woocommerce' => 'woocommerce/woocommerce.php',				// WooCommerce
-		'elementor' => 'elementor/elementor.php',					// Elementor
+		'woocommerce' => 'woocommerce/woocommerce.php',			// WooCommerce
+		'elementor' => 'elementor/elementor.php',			// Elementor
 		'elementor-pro' => 'elementor-pro/elementor-pro.php',		// Elementor Pro
 	),
 
@@ -27,8 +28,10 @@ new SelectivePluginLoader(
 	 * Step 2.
 	 *
 	 * Now, use the simplified labels to allow plugins on specified URLs. Use each label only once,
-	 * you can define as many URLs (even partially) as you need for each plugin label.
-	 * Format: 'plugin_label' => array('/page-url/', '/another-page-url/' ...)
+	 * you can define as many URLs (or partial URLs) as you need for each plugin label. Use regex to 
+         * make more complex matches.
+         *
+	 * Format: 'plugin_label' => array('/page-url/', '/another-page-url/', '/blog/[^/]+/?$', ...)
 	 *
 	 * WARNING: Partial matches also count! If the URL CONTAINS the string, then it matches, and the plugin
 	 * 			will be loaded. So "/product/" will also apply for "/product/my-product-1" and "/product/my-product-1"...

--- a/src/SelectivePluginLoader.php
+++ b/src/SelectivePluginLoader.php
@@ -30,7 +30,8 @@ class SelectivePluginLoader {
 	function handle( $plugins ) {
 		foreach ( $this->allow_on_pages as $pkey => $pages ) {
 			foreach ( $pages as $page ) {
-				if ( strpos( $this->request_uri, $page ) !== false ) {
+				if ( preg_match( '#' . $page . '#', $this->request_uri )
+                                  || strpos( $this->request_uri, $page ) !== false ) {
 					unset($this->disable_plugins[$pkey]);
 				}
 			}


### PR DESCRIPTION
The URIs passed to the second array in the constructor of SelectivePluginLoader can now use regex to give extra control on when a plugin is enabled (or disabled). 

Previously, due to the partial, it was impossible (for example) to specify that the plugin should only be shown on the home page only.

Some regex examples:

`/?$` -> matches the home page only (with or without the trailing slash) and does not allow partial matches of URLs
`/[^/]+/?$` -> matches any page except the home page
`(?!/(faq|search))/.+` -> matches any page except the home page, `/search` and `/faq`

This change is backwards compatible, so existing installations should not be affected, still allowing the user to specify `/events` to continue to match `/events` and any URL starting with `/events`.